### PR TITLE
Add info on JPL's contributions to the NISAR mission

### DIFF
--- a/introduction/about-jpl.md
+++ b/introduction/about-jpl.md
@@ -1,3 +1,14 @@
 # About the Jet Propulsion Laboratory
 
 The Jet Propulsion Laboratory (JPL) is located on the outskirts of Pasadena, California. Founded in 1936 by California Institute of Technology (Caltech) researchers, JPL is a research and development lab federally funded by NASA and managed by Caltech.
+
+[JPL leads the U.S. portion of the NISAR project on behalf of NASA](https://www.jpl.nasa.gov/press-kits/nisar/mission-overview/spacecraft/), and [provided the following components for the mission](https://science.nasa.gov/mission/nisar/about-the-satellite/): 
+* the L-band radar instrument
+* the antenna boom (the reflector was built by Astro Aerospace)
+* a high-rate communication subsystem for science data
+* GPS receivers
+* a solid-state recorder
+* a power distribution unit
+* a payload data subsystem
+
+JPL also oversaw the pre-launch testing of the radar antenna reflector and boom, and implemented remediation efforts to [address thermal vulnerabilities identified prior to launch](https://www.jpl.nasa.gov/images/pia26419-nisar-radar-antenna-reflector-loaded-for-return-to-india/). 


### PR DESCRIPTION
The About JPL section seemed out of place, as it wasn't tied specifically to the NISAR mission. This PR adds some context for the role JPL holds in the mission.