### PR TITLE
add github actions to deploy site preview on pr to ua-asf/nisar-docs:main

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -1,0 +1,60 @@
+name: Deploy site preview for PR
+
+on:
+  pull_request:
+    branches:
+      - main
+
+env:
+  BASE_URL: ${{ vars.PREVIEW_BASE_URL }}/${{ github.event.number }}
+  DOMAIN: ${{ vars.PREVIEW_DOMAIN }}
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group:  preview-${{ github.event.number }}
+
+jobs:
+  deploy-preview:
+    if: ${{ ! github.event.repository.fork }}
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -l {0}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          path: main
+
+      - uses: actions/checkout@v6
+        with:
+          repository: ${{ vars.PREVIEW_REPOSITORY }}
+          path: preview
+          token: ${{ secrets.PREVIEW_TOKEN }}
+
+      - uses: mamba-org/setup-micromamba@v2
+        with:
+          environment-file: main/environment.yml
+
+      - run: |
+          cd main
+          myst build --html
+          sed -i -e "s|http://localhost:3000|$DOMAIN$BASE_URL|g" $(grep -RIl "http://localhost:3000" ./_build)
+          cd ..
+
+          rm -R preview/${{ github.event.number }}
+          mv main/_build/html preview/${{ github.event.number }}
+
+          cd preview
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add ${{ github.event.number }}
+          git commit -m "deploy preview for PR #${{ github.event.number }} commit ${{ github.sha }}"
+          git push
+
+      - if: github.event.action == 'opened'
+        uses: thollander/actions-comment-pull-request@v3
+        with:
+          message: Preview deployed to ${{ env.DOMAIN }}${{ env.BASE_URL }}

--- a/.github/workflows/remove-preview.yml
+++ b/.github/workflows/remove-preview.yml
@@ -1,0 +1,28 @@
+name: Remove site preview for PR
+
+on:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - main
+
+concurrency:
+  group:  preview-${{ github.event.number }}
+
+jobs:
+  remove-preview:
+    if: ${{ ! github.event.repository.fork }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          repository: ${{ vars.PREVIEW_REPOSITORY }}
+          token: ${{ secrets.PREVIEW_TOKEN }}
+
+      - run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git rm -r ${{ github.event.number }}
+          git commit -m "remove preview for PR #${{ github.event.number }}"
+          git push

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0]
+
+### Added
+- A preview of the site is now automatically deployed to https://ua-asf.github.io/nisar-docs-preview/{pr_number}
+  for pull requests to ua-asf/nisar-docs:main.
+
 ## [0.1.0]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -12,26 +12,6 @@ Source for the public documentation of the NASA-ISRO Synthetic Aperture Radar (N
    mamba activate nisar-docs
     ```
 1. Run `myst start` to render the website on your local machine
-1. Configure previewing via GitHub Pages (optional)
-   1. Enable GitHub Actions for your fork
-      <details>
-      <summary>screenshot</summary>
-      <img alt="screenshot of enabling GitHub Actions" src="assets/readme_enable_actions.png" />
-      </details>
-   1. Enable GitHub Pages for your fork with Source = GitHub Actions
-      <details>
-      <summary>screenshot</summary>
-      <img alt="screenshot of enabling GitHub Pages" src="assets/readme_enable_pages.png" />
-      </details>
-   1. Create two GitHub Actions variables:
-      1. `BASE_URL` with a value of `/nisar-docs` (including the leading `/`)
-      2. `DOMAIN` with a value of `https://{github_user_id}.github.io`
-      <details>
-      <summary>screenshot</summary>
-      <img alt="screenshot of creating BASE_URL variable" src="assets/readme_variables.png" />
-      </details>
-   1. Push changes to your `main` branch
-   1. Preview the rendered site at `https://{github_user_id}.github.io/nisar-docs/`
 1. Make and commit your changes
 1. Push changes to your fork in GitHub
 1. Make sure your branch is synced and up to date with `ua-asf/nisar-docs:main`


### PR DESCRIPTION
TODO:
- [x] create ua-asf/nisar-docs-preview repository:
    - [ ] set up branch protection
    - [x] add emtpry `.nojekll` file to repository root
    - [x] enable github pages to deploy from `main`
    - [x] add nisar-docs team as repository admins
- [x] create github token with `contents: write` permissions for ua-asf/nisar-docs-preview
- [x] github actions secrets/variables:
    - [x] PREVIEW_TOKEN secret
    - [x] PREVIEW_BASE_URL variable `/nisar-docs-preview`
    - [x] PREVIEW_DOMAIN variable `https://ua-asf.github.io`
    - [x] PREVIEW_REPOSITORY variable `ua-asf/nisar-docs-preview`
- [x] set "Approval for running fork pull request workflows from contributors" to "Require approval for all external contributors "