### PR TITLE
Release v0.4.10

### DIFF
--- a/.github/workflows/validate-cff.yml
+++ b/.github/workflows/validate-cff.yml
@@ -1,0 +1,23 @@
+name: Validate CFF file
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - CITATION.cff
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out a copy of the repository
+        uses: actions/checkout@v6
+
+      - name: Check whether the citation metadata from CITATION.cff is valid
+        uses: citation-file-format/cffconvert-github-action@2.0.0
+        with:
+          args: "--validate"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.9]
+
+### Added
+- A `citation.cff` file to provide citation metadata for this guide.
+- A GitHub action to validate chages to the `citation.cff` file. 
 
 ## [0.4.9]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - A `citation.cff` file to provide citation metadata for this guide.
-- A GitHub action to validate chages to the `citation.cff` file. 
+- A GitHub action to validate chages to the `citation.cff` file.
+- Add Zenodo "project" DOI to README that will always resolve to the latest version on Zenodo. 
 
 ## [0.4.9]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.4.9]
+## [0.4.10]
 
 ### Added
 - A `citation.cff` file to provide citation metadata for this guide.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,79 @@
+cff-version: 1.2.0
+message: >-
+  If you use this software, please cite it using the
+  metadata from this file.
+
+title: NISAR Data User Guide
+# doi: 10.5281/zenodo.XXXXXXX
+contact:
+  - name: NASA Earthdata Forum
+    website: https://forum.earthdata.nasa.gov/viewforum.php?f=7&keywords=NISAR
+  - name: ASF User Services
+    email: uso@asf.alaska.edu
+type: software
+license: CC0-1.0
+url: https://nisar-docs.asf.alaska.edu/
+repository-code: https://github.com/ua-asf/nisar-docs
+keywords:
+  - NISAR
+  - data
+  - remote sensing
+  - earth science
+  - land surface
+  - geomorphic landforms
+  - geomorphic processes
+  - solid earth
+  - tectonics
+  - agriculture
+  - forest science
+  - cryosphere
+  - glaciers
+  - ice sheets
+  - frozen ground
+authors:
+  - family-names: Kristenson
+    given-names: Heidi
+    affiliation: Alaska Satellite Facility, Geophysical Institute, University of Alaska Fairbanks, Fairbanks, AK USA
+    orcid: https://orcid.org/0000-0002-2130-4527
+    alias: hjkristenson
+  - given-names: Jacquelyn
+    family-names: Smale
+    affiliation: Alaska Satellite Facility, Geophysical Institute, University of Alaska Fairbanks, Fairbanks, AK USA
+    orcid: https://orcid.org/0000-0002-2749-5010
+    alias: jacquelynsmale
+  - given-names: Andrew
+    family-names: Johnston
+    affiliation: Alaska Satellite Facility, Geophysical Institute, University of Alaska Fairbanks, Fairbanks, AK USA
+    alias: asjohnston-asf
+  - given-names: Jake
+    family-names: Herrmann
+    affiliation: Alaska Satellite Facility, Geophysical Institute, University of Alaska Fairbanks, Fairbanks, AK USA
+    alias: jtherrmann
+  - given-names: Rudi
+    family-names: Gens
+    affiliation: Alaska Satellite Facility, Geophysical Institute, University of Alaska Fairbanks, Fairbanks, AK USA
+    orcid: https://orcid.org/0000-0002-1962-9787
+    alias: rudigens
+  - given-names: Joseph H
+    family-names: Kennedy
+    affiliation: Alaska Satellite Facility, Geophysical Institute, University of Alaska Fairbanks, Fairbanks, AK USA
+    orcid: https://orcid.org/0000-0002-9348-693X
+    alias: jhkennedy
+  - given-names: Jules
+    family-names: White
+    affiliation: Alaska Satellite Facility, Geophysical Institute, University of Alaska Fairbanks, Fairbanks, AK USA
+    alias: jwhite124
+  - given-names: Alex
+    family-names: Lewandowski
+    affiliation: Alaska Satellite Facility, Geophysical Institute, University of Alaska Fairbanks, Fairbanks, AK USA
+    orcid: https://orcid.org/0009-0006-9584-0687
+    alias: Alex-Lewandowski
+  - given-names: William
+    family-names: Horn
+    affiliation: Alaska Satellite Facility, Geophysical Institute, University of Alaska Fairbanks, Fairbanks, AK USA
+    alias: williamh890
+  - given-names: Heresh
+    family-names: Fattahi
+    affiliation: Jet Propulsion Laboratory, California Institute of Technology, Pasadena, CA, USA
+    orcid: https://orcid.org/0000-0001-6926-4387
+    alias: hfattahi

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -72,7 +72,7 @@ authors:
   - given-names: William
     family-names: Horn
     affiliation: Alaska Satellite Facility, Geophysical Institute, University of Alaska Fairbanks, Fairbanks, AK USA
-    orchid: https://orcid.org/0009-0003-8206-5982
+    orcid: https://orcid.org/0009-0003-8206-5982
     alias: williamh890
   - given-names: Heresh
     family-names: Fattahi

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -16,6 +16,14 @@ url: https://nisar-docs.asf.alaska.edu/
 repository-code: https://github.com/ua-asf/nisar-docs
 keywords:
   - NISAR
+  - NASA-ISRO Synthetic Aperture Radar
+  - Synthetic Aperture Radar
+  - SAR
+  - NASA
+  - Alaska Satellite Facility
+  - ASF
+  - Jet Propulsion Laboratory
+  - JPL
   - data
   - remote sensing
   - earth science

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -10,7 +10,7 @@ contact:
     website: https://forum.earthdata.nasa.gov/viewforum.php?f=7&keywords=NISAR
   - name: ASF User Services
     email: uso@asf.alaska.edu
-type: software
+type: dataset
 license: CC0-1.0
 url: https://nisar-docs.asf.alaska.edu/
 repository-code: https://github.com/ua-asf/nisar-docs

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -59,9 +59,10 @@ authors:
     affiliation: Alaska Satellite Facility, Geophysical Institute, University of Alaska Fairbanks, Fairbanks, AK USA
     orcid: https://orcid.org/0000-0002-9348-693X
     alias: jhkennedy
-  - given-names: Jules
+  - given-names: Julia
     family-names: White
     affiliation: Alaska Satellite Facility, Geophysical Institute, University of Alaska Fairbanks, Fairbanks, AK USA
+    orcid: https://orcid.org/0009-0008-5177-3122
     alias: jwhite124
   - given-names: Alex
     family-names: Lewandowski
@@ -71,6 +72,7 @@ authors:
   - given-names: William
     family-names: Horn
     affiliation: Alaska Satellite Facility, Geophysical Institute, University of Alaska Fairbanks, Fairbanks, AK USA
+    orchid: https://orcid.org/0009-0003-8206-5982
     alias: williamh890
   - given-names: Heresh
     family-names: Fattahi

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -4,7 +4,7 @@ message: >-
   metadata from this file.
 
 title: NISAR Data User Guide
-# doi: 10.5281/zenodo.XXXXXXX
+doi: 10.5281/zenodo.20075813
 contact:
   - name: NASA Earthdata Forum
     website: https://forum.earthdata.nasa.gov/viewforum.php?f=7&keywords=NISAR

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 Source for the public documentation of the NASA-ISRO Synthetic Aperture Radar (NISAR) mission hosted at https://nisar-docs.asf.alaska.edu.
 
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20075813.svg)](https://doi.org/10.5281/zenodo.20075813)
+
+
 ## Contributing
 
 1. Create a fork of https://github.com/ua-asf/nisar-docs/

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Source for the public documentation of the NASA-ISRO Synthetic Aperture Radar (NISAR) mission hosted at https://nisar-docs.asf.alaska.edu.
 
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20075813.svg)](https://doi.org/10.5281/zenodo.20075813)
+[![DOI](https://img.shields.io/badge/DOI-10.5281%2Fzenodo.20075813-blue.svg)](https://doi.org/10.5281/zenodo.20075813)
 
 
 ## Contributing


### PR DESCRIPTION
This adds a `citation.cff` and validation GitHub action, similar to what we've done in HyP3 Docs and Autorift. 

Notably, this time I've included affiliations and "alias" to represent the GitHub User IDs of the contributors, both of which I think are important for a community guide. If I knew the associated ORCID ID, I included it as well.

Authors are ordered according to how they show up in the "contributors" sidebar on the repository home page. It would be good to double-check the detailed contributors page, but I couldn't get it to load:
https://github.com/ua-asf/nisar-docs/graphs/contributors

fixes #126 