### PR TITLE
Add workflow to check that all contributors have been credited as authors

### DIFF
--- a/.github/workflows/contributor-check.yml
+++ b/.github/workflows/contributor-check.yml
@@ -1,0 +1,22 @@
+name: Contributor Check
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write # allows posting comments on PRs
+
+jobs:
+  contrib-check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Contrib metadata check
+        uses: vuillaut/contrib-checker@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          mode: warn  # or 'fail' to make the workflow fail when contributors are missing
+          ignore_emails: "dependabot[bot]@users.noreply.github.com"
+          ignore_logins: "dependabot[bot],github-actions[bot]"

--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,5 @@
+Alex Lewandowski <aflewandowski@alaska.edu>
+Alex Lewandowski <aflewandowski@alaska.edu> <37909088+Alex-Lewandowski@users.noreply.github.com>
+Heidi Kristenson <hjkristenson@alaska.edu>
+Jacquelyn Smale <jacquelyn.smale@gmail.com>
+Julia White <jwhite124@alaska.edu>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.11]
+
+### Added
+- A GitHub Actions workflow to ensure all (git) contributors have been added to the `citation.cff` file
+- A `.mailmap` file to connect the varying ways contributors represent their names and emails to their entry in `citation.cff`
+
 ## [0.4.10]
 
 ### Added


### PR DESCRIPTION
This is a follow-up to #128, which resolved #126, to provide a way to check that everyone who has contributed to this repository via git commits has been listed as an author in the `citation.cff` file.

The workflow uses:
 https://github.com/marketplace/actions/contributors-metadata-check

This is, I think, a good practice, but I'm not sure we want to add the `.mailmap` file, which is essential to get this workflow running well. Notably, everything in the `.mailmap` file is public in the commits, but it adds another config file to the repo, and it isn't immediately obvious what it's for. 