### PR TITLE
update data release timeline to reflect no changes as of May 2026

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.13]
+
+### Changed
+- Updated data release timeline to reflect no changes as of May 2026.
+
 ## [0.4.12] 
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Tools and Services section describing development efforts leveraging Earthdata tools and services
 - Roadmap outlining ASF's development efforts in support of Earthdata tools and services
+- Removed Appendices section and moved content into Resources section
 
 ## [0.4.11]
 

--- a/data-availability/availability-overview.md
+++ b/data-availability/availability-overview.md
@@ -56,7 +56,7 @@ Spatial extent of NISAR L-band data collection, highlighted in green.
 
 The NISAR project will generate Level 0-3 data products from all L-band data acquired since September 23, 2025. All L-band data products will be available to the public through the Alaska Satellite Facility.
 
-The nominal data release timeline as of April 2026 is described below.
+The nominal data release timeline as of May 2026 is described below.
 
 ### Jan 2026: Sample products
 An [initial release](https://www.earthdata.nasa.gov/news/nisar-sample-data-products-available) of 25 pre-calibration sample data products were made available on January 23, 2026. This release included one or more products of each of the nine Level 1-3 product types.


### PR DESCRIPTION
also adds a changelog entry for a change already delivered in v0.4.12